### PR TITLE
Add capacity to automatically detect the module to use depending on the position

### DIFF
--- a/src/org/openstreetmap/josm/plugins/pointinfo/AbstractPointInfoModule.java
+++ b/src/org/openstreetmap/josm/plugins/pointinfo/AbstractPointInfoModule.java
@@ -29,4 +29,10 @@ public abstract class AbstractPointInfoModule {
      * @return String name
      */
     public abstract String getName();
+
+    /**
+     * Returns the name of the area (country, state) where this module is valid
+     * @return String areaName
+     */
+    public abstract String getArea();
 }

--- a/src/org/openstreetmap/josm/plugins/pointinfo/PointInfoAction.java
+++ b/src/org/openstreetmap/josm/plugins/pointinfo/PointInfoAction.java
@@ -73,9 +73,9 @@ class PointInfoAction extends MapMode implements MouseListener {
          * Positional data
          */
         final LatLon pos = MainApplication.getMap().mapView.getLatLon(clickPoint.x, clickPoint.y);
-        module = PointInfoPlugin.getModule();
 
         try {
+            module = PointInfoPlugin.getModule(pos);
             PleaseWaitRunnable infoTask = new PleaseWaitRunnable(tr("Connecting server")) {
                 @Override
                 protected void realRun() throws SAXException {

--- a/src/org/openstreetmap/josm/plugins/pointinfo/PointInfoPreference.java
+++ b/src/org/openstreetmap/josm/plugins/pointinfo/PointInfoPreference.java
@@ -7,6 +7,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 
 import javax.swing.Box;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -22,6 +23,7 @@ import org.openstreetmap.josm.tools.GBC;
 public class PointInfoPreference extends DefaultTabPreferenceSetting {
 
     private final JComboBox<String> module = new JComboBox<>();
+    private final JCheckBox autoMode = new JCheckBox(tr("Automatically detect the module"));
 
     /**
      * Constructs a new {@code PointInfoPreference}.
@@ -38,6 +40,12 @@ public class PointInfoPreference extends DefaultTabPreferenceSetting {
     @Override
     public void addGui(PreferenceTabbedPane gui) {
         JPanel panel = new JPanel(new GridBagLayout());
+        // autoMode
+        autoMode.setSelected(Main.pref.getBoolean("plugin.pointinfo.automode", true));
+        autoMode.setToolTipText(tr("Try to guess the appropriate module from the location."
+                + " If it fails, use the module selected below."));
+        panel.add(autoMode, GBC.eol().insets(0, 0, 0, 0));
+        // module
         for (String modName : PointInfoPlugin.getModules()) {
             module.addItem(modName);
         }
@@ -51,6 +59,7 @@ public class PointInfoPreference extends DefaultTabPreferenceSetting {
 
     @Override
     public boolean ok() {
+        Main.pref.putBoolean("plugin.pointinfo.automode", autoMode.isSelected());
         Main.pref.put("plugin.pointinfo.module", (String) module.getSelectedItem());
         return false;
     }

--- a/src/org/openstreetmap/josm/plugins/pointinfo/ReverseFinder.java
+++ b/src/org/openstreetmap/josm/plugins/pointinfo/ReverseFinder.java
@@ -1,0 +1,43 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.pointinfo;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+import java.util.Locale;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.openstreetmap.josm.data.coor.LatLon;
+import org.openstreetmap.josm.tools.HttpClient;
+
+/**
+ * Class to access Nominatim Reverse Geocoding
+ * @author Javier Sánchez Portero
+ */
+public class ReverseFinder {
+
+    public static final String NOMINATIM_URL = "https://nominatim.openstreetmap.org/reverse?format=json&lat=%f&lon=%f";
+
+    private ReverseFinder() {
+    }
+
+    /**
+     * Performs a Nominatim search.
+     * @param pos Coordinates to search
+     * @return search results
+     * @throws IOException if any IO error occurs.
+     */
+    public static ReverseRecord queryNominatim(LatLon pos) throws IOException {
+        String request = String.format(Locale.ENGLISH, NOMINATIM_URL, pos.lat(), pos.lon());
+        String result = HttpClient.create(new URL(request)).connect().fetchContent();
+        JsonReader jsonReader = Json.createReader(new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8)));
+        JsonObject obj = jsonReader.readObject();
+        jsonReader.close();
+        ReverseRecord record = new ReverseRecord(obj);
+        return record;
+    }
+}

--- a/src/org/openstreetmap/josm/plugins/pointinfo/ReverseRecord.java
+++ b/src/org/openstreetmap/josm/plugins/pointinfo/ReverseRecord.java
@@ -72,7 +72,7 @@ class ReverseRecord {
      * @return match
      */
     public Boolean matchAnyArea(String area) {
-s        if (area.equals(countryCode)) return true;
+        if (area.equals(countryCode)) return true;
         if (area.equals(country)) return true;
         if (area.equals(state)) return true;
         if (area.equals(stateDistrict)) return true;

--- a/src/org/openstreetmap/josm/plugins/pointinfo/ReverseRecord.java
+++ b/src/org/openstreetmap/josm/plugins/pointinfo/ReverseRecord.java
@@ -1,0 +1,87 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.pointinfo;
+
+import javax.json.JsonObject;
+
+/**
+ * Class to contain Nominatim Reverse Geocoding data
+ * @author Javier Sánchez Portero
+ */
+class ReverseRecord {
+
+    private String countryCode;
+    private String country;
+    private String state;
+    private String stateDistrict;
+    private String county;
+    private String city;
+    private String town;
+    private String village;
+    private String cityDistrict;
+    private String suburb;
+    
+    /**
+     * Default constructor
+     *
+     */
+    ReverseRecord() {
+        init();
+    }
+
+    /**
+     * Constructor from JSON
+     *
+     */
+    ReverseRecord(JsonObject obj) {
+        init();
+        JsonObject address = obj.getJsonObject("address");
+        if (address != null) {
+            countryCode = address.getString("country_code", null);
+            country = address.getString("country", null);
+            state = address.getString("state", null);
+            stateDistrict = address.getString("state_district", null);
+            county = address.getString("county", null);
+            city = address.getString("city", null);
+            town = address.getString("town", null);
+            village = address.getString("village", null);
+            cityDistrict = address.getString("city_district", null);
+            suburb = address.getString("suburb", null);
+        }
+    }
+
+    /**
+     * Initialization
+     *
+     */
+    private void init() {
+        countryCode = null;
+        country = null;
+        state = null;
+        stateDistrict = null;
+        county = null;
+        city = null;
+        town = null;
+        village = null;
+        cityDistrict = null;
+        suburb = null;
+    }
+    
+    /**
+     * Returns true if area is equals to any address value
+     * @param area
+     * @return match
+     */
+    public Boolean matchAnyArea(String area) {
+s        if (area.equals(countryCode)) return true;
+        if (area.equals(country)) return true;
+        if (area.equals(state)) return true;
+        if (area.equals(stateDistrict)) return true;
+        if (area.equals(county)) return true;
+        if (area.equals(city)) return true;
+        if (area.equals(town)) return true;
+        if (area.equals(village)) return true;
+        if (area.equals(cityDistrict)) return true;
+        if (area.equals(suburb)) return true;
+        return false;
+    }
+}

--- a/src/org/openstreetmap/josm/plugins/pointinfo/catastro/CatastroModule.java
+++ b/src/org/openstreetmap/josm/plugins/pointinfo/catastro/CatastroModule.java
@@ -17,6 +17,7 @@ import org.openstreetmap.josm.plugins.pointinfo.AbstractPointInfoModule;
 public class CatastroModule extends AbstractPointInfoModule {
 
     private static final String moduleName = "Catastro";
+    private static final String areaName = "es";
     private static final String catURL = "http://ovc.catastro.meh.es/ovcservweb/OVCSWLocalizacionRC/OVCCoordenadas.asmx/Consulta_RCCOOR?SRS=EPSG:4326&Coordenada_X=%f&Coordenada_Y=%f";
 
     private CatastroRecord m_record = new CatastroRecord();
@@ -53,5 +54,10 @@ public class CatastroModule extends AbstractPointInfoModule {
     @Override
     public String getName() {
         return moduleName;   
+    }
+
+    @Override
+    public String getArea() {
+        return areaName;
     }
 }

--- a/src/org/openstreetmap/josm/plugins/pointinfo/ruian/RuianModule.java
+++ b/src/org/openstreetmap/josm/plugins/pointinfo/ruian/RuianModule.java
@@ -16,6 +16,7 @@ import org.openstreetmap.josm.plugins.pointinfo.AbstractPointInfoModule;
 public class RuianModule extends AbstractPointInfoModule {
 
     private static final String moduleName = "RUIAN";
+    private static final String areaName = "cz";
     private static final String URL = "http://josm.poloha.net/pointInfo/v4/index.php";
 
     private RuianRecord m_record = new RuianRecord();
@@ -51,5 +52,10 @@ public class RuianModule extends AbstractPointInfoModule {
     @Override
     public String getName() {
         return moduleName;   
+    }
+
+    @Override
+    public String getArea() {
+        return areaName;
     }
 }


### PR DESCRIPTION
Hello.

As commented, I tried to guess the country with a query to Nominatim. These are the changes:
PointInfoPreference adds a checkbox to select "Auto mode".
AbstractPointInfoModule adds a method to return the name of the area this module is valid.
ReverseFinder to query Nominatim for the address of a given position.
ReverseRecord to holds the results of the previous query.
PointInfoUtils.getModule returns the module for the area detected if auto mode is on or the selected in the preferences if else.